### PR TITLE
Switching to simplified byte_to_spi_bytes function

### DIFF
--- a/src/wire_protocol.rs
+++ b/src/wire_protocol.rs
@@ -1,7 +1,16 @@
+// New method to convert byte to spi bytes
+pub fn byte_to_spi_bytes(byte: u8) -> [u8; 3] {
+	[
+		0b00100100 + (byte<<1&0b10) + (byte<<3&0b10000) + (byte<<5&0b10000000),
+		0b01001001 + (byte>>1&0b100) + (byte<<1&0b100000),
+		0b10010010 + (byte>>5&0b1) + (byte>>3&0b1000) + (byte>>1&0b1000000)
+	]
+}
+
 // Convert panel bits into their SPI counterparts
 // 0 -> 001
 // 1 -> 011
-pub fn byte_to_spi_bytes(input: u8) -> [u8; 3] {
+pub fn byte_to_spi_bytes_old(input: u8) -> [u8; 3] {
     // first convert the u8 to 24 bits
     let mut bool_array = [false; 24];
     for bit_index in 0..8 {


### PR DESCRIPTION
Hello,
I'm thinking about using that library in my next raspi project, and I just had an idea while looking at the code.

The `byte_to_spi_bytes` function looks quite heavy because it needs 24 bytes on the memory and does a lot of logic to split the value into the array and then merge it back. If you're doing fast animations maybe this could decrease performance, I think the algorithm could be simplified a lot by just hardcoding the math operations.

This makes the code less extensible, but I think also more performant, I didn't benchmark it but it passes the tests and it looks a lot more lightweight to me. Also I guess there probably won't be a need for extensibility, as we only need to encode bytes and nothing else.

Please tell me your thoughts on this one :)